### PR TITLE
Additional Iter Functions and Iterator Methods

### DIFF
--- a/iter/collectors.go
+++ b/iter/collectors.go
@@ -1,6 +1,10 @@
 package iter
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"strings"
+)
 
 // CollectSlice consumes the provided Interface into a slice of type T.
 func CollectSlice[T any](from Interface[T]) []T {
@@ -56,4 +60,22 @@ func CollectChan[T any](ctx context.Context, from Interface[T], buffer int) <-ch
 		}
 	}(out)
 	return out
+}
+
+// Join consumes all values in the provided iterator and concatenates the
+// elements to create a single string.
+//
+// The separator string sep is placed between elements in the resulting string.
+func Join(iter Interface[string], sep string) string {
+	return strings.Join(CollectSlice(iter), sep)
+}
+
+// JoinStringer behaves similarly to Join but accepts any value which can be
+// converted to a string via the fmt.Stringer interface.
+//
+// For additional details see Join and fmt.Stringer.
+func JoinStringer[T fmt.Stringer](iter Interface[T], sep string) string {
+	return Join(Map(iter, func(f T) string {
+		return f.String()
+	}), sep)
 }

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -482,8 +482,7 @@ func Sorted[T any](iter Interface[T], lessFunc func(a, b T) bool) Interface[T] {
 }
 
 // iterSort enables dynamically sorting values of type T using a specified
-// implementation of the Less function required to implement the sort.Interface
-// interface.
+// implementation of the Less function required to implement the sort.Interface.
 type iterSort[T any] struct {
 	lessFunc func(a, b T) bool
 	data     []T

--- a/iter/iter.go
+++ b/iter/iter.go
@@ -1,6 +1,10 @@
 package iter
 
-import "github.com/moogar0880/oxide"
+import (
+	"sort"
+
+	"github.com/moogar0880/oxide"
+)
 
 // Count consumes the provided iterator, returning the number of iterations
 // that were made before the first None value is encountered.
@@ -466,4 +470,39 @@ func Interleave[T any](iter1, iter2 Interface[T]) Interface[T] {
 		iterJ:           iter2,
 		nextComingFromJ: false,
 	}
+}
+
+// Sorted returns an Interface in which all elements are sorted according to
+// the provided sorting function.
+func Sorted[T any](iter Interface[T], lessFunc func(a, b T) bool) Interface[T] {
+	sorter := &iterSort[T]{lessFunc: lessFunc, data: CollectSlice(iter)}
+	sort.Sort(sorter)
+
+	return FromSlice(sorter.data)
+}
+
+// iterSort enables dynamically sorting values of type T using a specified
+// implementation of the Less function required to implement the sort.Interface
+// interface.
+type iterSort[T any] struct {
+	lessFunc func(a, b T) bool
+	data     []T
+}
+
+// Len implements sort.Interface and returns the number of elements in the
+// collection.
+func (s *iterSort[T]) Len() int {
+	return len(s.data)
+}
+
+// Less implements sort.Interface and reports whether the element with index i
+// must sort before the element with index j.
+func (s *iterSort[T]) Less(i, j int) bool {
+	return s.lessFunc(s.data[i], s.data[j])
+}
+
+// Swap implements sort.Interface and is responsible for swapping the elements
+// with indexes i and j.
+func (s *iterSort[T]) Swap(i, j int) {
+	s.data[i], s.data[j] = s.data[j], s.data[i]
 }

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -835,6 +835,56 @@ func TestInterleave(t *testing.T) {
 	}
 }
 
+func TestSort(t *testing.T) {
+	testIO := []struct {
+		name     string
+		iter     Interface[int]
+		lessFunc func(i, j int) bool
+		expect   []int
+	}{
+		{
+			name:     "should sort empty iterator",
+			iter:     FromSlice([]int{}),
+			lessFunc: func(i, j int) bool { return i < j },
+			expect:   []int{},
+		},
+		{
+			name:     "should sort iterator with single value",
+			iter:     FromSlice([]int{1}),
+			lessFunc: func(i, j int) bool { return i < j },
+			expect:   []int{1},
+		},
+		{
+			name:     "should sort already sorted iterator",
+			iter:     FromSlice([]int{1, 2, 3, 4, 5}),
+			lessFunc: func(i, j int) bool { return i < j },
+			expect:   []int{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "should sort unsorted iterator",
+			iter:     FromSlice([]int{2, 6, 3, 1, 4, 5}),
+			lessFunc: func(i, j int) bool { return i < j },
+			expect:   []int{1, 2, 3, 4, 5, 6},
+		},
+		{
+			name:     "should sort in reverse order",
+			iter:     FromSlice([]int{2, 6, 3, 1, 4, 5}),
+			lessFunc: func(i, j int) bool { return i > j },
+			expect:   []int{6, 5, 4, 3, 2, 1},
+		},
+	}
+
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			iterator := Sorted(test.iter, test.lessFunc)
+
+			actual := CollectSlice(iterator)
+
+			assert.Equal(t, test.expect, actual)
+		})
+	}
+}
+
 type unboundedIterator struct{}
 
 func (*unboundedIterator) Next() (data int, present bool) { return }

--- a/iter/iter_test.go
+++ b/iter/iter_test.go
@@ -783,6 +783,58 @@ func TestIntersperse(t *testing.T) {
 	}
 }
 
+func TestInterleave(t *testing.T) {
+	testIO := []struct {
+		name       string
+		iter1      Interface[int]
+		iter2      Interface[int]
+		expect     []int
+		expectSize oxide.Option[int64]
+	}{
+		{
+			name:       "should interleave balanced values",
+			iter1:      FromSlice([]int{1, 3, 5, 7, 9}),
+			iter2:      FromSlice([]int{2, 4, 6, 8, 10}),
+			expect:     []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			expectSize: oxide.Some[int64](10),
+		},
+		{
+			name:       "should interleave unbalanced values (left heavy)",
+			iter1:      FromSlice([]int{1, 3, 5}),
+			iter2:      FromSlice([]int{2}),
+			expect:     []int{1, 2, 3, 5},
+			expectSize: oxide.Some[int64](4),
+		},
+		{
+			name:       "should interleave unbalanced values (right heavy)",
+			iter1:      FromSlice([]int{1}),
+			iter2:      FromSlice([]int{2, 4, 6}),
+			expect:     []int{1, 2, 4, 6},
+			expectSize: oxide.Some[int64](4),
+		},
+		{
+			name:       "should return no values and have no size hint if both iterators do not implement SizeHint",
+			iter1:      new(unboundedIterator),
+			iter2:      new(unboundedIterator),
+			expect:     []int{},
+			expectSize: oxide.None[int64](),
+		},
+	}
+
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			iterator := Interleave(test.iter1, test.iter2)
+			lower, size := iterator.(SizeHinter).SizeHint()
+			assert.Equal(t, int64(0), lower)
+			assert.Equal(t, test.expectSize, size)
+
+			actual := CollectSlice(iterator)
+
+			assert.Equal(t, test.expect, actual)
+		})
+	}
+}
+
 type unboundedIterator struct{}
 
 func (*unboundedIterator) Next() (data int, present bool) { return }

--- a/iterator/iterator.go
+++ b/iterator/iterator.go
@@ -103,6 +103,12 @@ func (i *Iterator[T]) Intersperse(sep T) *Iterator[T] {
 	return NewIterator(iter.Intersperse(i.inner, sep))
 }
 
+// Interleave returns a new Iterator which alternates elements from two
+// iterators until both Iterators are fully consumed.
+func (i *Iterator[T]) Interleave(other iter.Interface[T]) *Iterator[T] {
+	return NewIterator(iter.Interleave(i.inner, other))
+}
+
 // Count consumes the Iterator and returns the count of all items in the
 // iterator.
 func (i *Iterator[T]) Count() int {

--- a/iterator/iterator.go
+++ b/iterator/iterator.go
@@ -109,6 +109,12 @@ func (i *Iterator[T]) Interleave(other iter.Interface[T]) *Iterator[T] {
 	return NewIterator(iter.Interleave(i.inner, other))
 }
 
+// Sorted returns a new Iterator in which all elements are sorted according to
+// the provided sorting function.
+func (i *Iterator[T]) Sorted(lessFunc func(i, j T) bool) *Iterator[T] {
+	return NewIterator(iter.Sorted(i.inner, lessFunc))
+}
+
 // Count consumes the Iterator and returns the count of all items in the
 // iterator.
 func (i *Iterator[T]) Count() int {

--- a/iterator/iterator_test.go
+++ b/iterator/iterator_test.go
@@ -826,3 +826,39 @@ func TestIterator_Intersperse(t *testing.T) {
 		})
 	}
 }
+
+func TestIterator_Interleave(t *testing.T) {
+	testIO := []struct {
+		name   string
+		iter1  *Iterator[int]
+		iter2  iter.Interface[int]
+		expect []int
+	}{
+		{
+			name:   "should interleave balanced values",
+			iter1:  FromSlice([]int{1, 3, 5, 7, 9}),
+			iter2:  FromSlice([]int{2, 4, 6, 8, 10}),
+			expect: []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+		{
+			name:   "should interleave unbalanced values (left heavy)",
+			iter1:  FromSlice([]int{1, 3, 5}),
+			iter2:  FromSlice([]int{2}),
+			expect: []int{1, 2, 3, 5},
+		},
+		{
+			name:   "should interleave unbalanced values (right heavy)",
+			iter1:  FromSlice([]int{1}),
+			iter2:  FromSlice([]int{2, 4, 6}),
+			expect: []int{1, 2, 4, 6},
+		},
+	}
+
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.iter1.Interleave(test.iter2).CollectSlice()
+
+			assert.Equal(t, test.expect, actual)
+		})
+	}
+}

--- a/iterator/iterator_test.go
+++ b/iterator/iterator_test.go
@@ -862,3 +862,52 @@ func TestIterator_Interleave(t *testing.T) {
 		})
 	}
 }
+
+func TestIterator_Sort(t *testing.T) {
+	testIO := []struct {
+		name     string
+		iter     *Iterator[int]
+		lessFunc func(i, j int) bool
+		expect   []int
+	}{
+		{
+			name:     "should sort empty iterator",
+			iter:     FromSlice([]int{}),
+			lessFunc: func(i, j int) bool { return i < j },
+			expect:   []int{},
+		},
+		{
+			name:     "should sort iterator with single value",
+			iter:     FromSlice([]int{1}),
+			lessFunc: func(i, j int) bool { return i < j },
+			expect:   []int{1},
+		},
+		{
+			name:     "should sort already sorted iterator",
+			iter:     FromSlice([]int{1, 2, 3, 4, 5}),
+			lessFunc: func(i, j int) bool { return i < j },
+			expect:   []int{1, 2, 3, 4, 5},
+		},
+		{
+			name:     "should sort unsorted iterator",
+			iter:     FromSlice([]int{2, 6, 3, 1, 4, 5}),
+			lessFunc: func(i, j int) bool { return i < j },
+			expect:   []int{1, 2, 3, 4, 5, 6},
+		},
+		{
+			name:     "should sort in reverse order",
+			iter:     FromSlice([]int{2, 6, 3, 1, 4, 5}),
+			lessFunc: func(i, j int) bool { return i > j },
+			expect:   []int{6, 5, 4, 3, 2, 1},
+		},
+	}
+
+	for _, test := range testIO {
+		t.Run(test.name, func(t *testing.T) {
+			iterator := test.iter.Sorted(test.lessFunc)
+			actual := iterator.CollectSlice()
+
+			assert.Equal(t, test.expect, actual)
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the following functions to the `iter` package:

* `Join`
* `JoinStringer`
* `Interleave`
* `Sort`

As well as the following methods to the `iterator.Iterator` type

* `Interleave`
* `Sort`